### PR TITLE
Fix of Register User API

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -162,7 +162,7 @@ The domain diagram can [be found here on LucidChart](https://lucid.app/lucidchar
   ```json
   {
     "email": "dupa@google.com",
-    "userId": "u1",
+    "id": "u1"
   }
   ```
 

--- a/frontend/lib/api/authentication/authentication_api.dart
+++ b/frontend/lib/api/authentication/authentication_api.dart
@@ -9,5 +9,5 @@ class AuthenticationApi {
 
   AuthenticationApi(DioWrapper dioWrapper) : _dioWrapper = dioWrapper;
 
-  Future<Result<void>> addUser(AddUserRequest request) => _dioWrapper.post(_baseUrl, data: request.toJson());
+  Future<Result<void>> addUser(AddUserRequest request) => _dioWrapper.post('$_baseUrl/', data: request.toJson());
 }

--- a/frontend/lib/api/authentication/requests/add_user_request.dart
+++ b/frontend/lib/api/authentication/requests/add_user_request.dart
@@ -6,6 +6,6 @@ class AddUserRequest {
 
   Map<String, dynamic> toJson() => {
         'email': email,
-        'userId': userId,
+        'id': userId,
       };
 }


### PR DESCRIPTION
Backend uses `id`, in our documentation it was `userId`